### PR TITLE
Support prismaSchemaFolder preview feature

### DIFF
--- a/src/generator/generator.test.ts
+++ b/src/generator/generator.test.ts
@@ -5,13 +5,25 @@ import {join} from 'node:path';
 import {packageDir} from '../util/file-paths.js';
 
 describe('prisma-frontend', () => {
-    it('works', async () => {
+    it('works with a single schema file', async () => {
         await rm(join(packageDir, 'node_modules', '.prisma'), {
             recursive: true,
             force: true,
         });
 
         await runShellCommand('npx prisma generate --schema=test-files/schema.prisma --no-hints', {
+            rejectOnError: true,
+            hookUpToConsole: true,
+        });
+    });
+
+    it('works with prismaSchemaFolder preview feature enabled', async () => {
+        await rm(join(packageDir, 'node_modules', '.prisma'), {
+            recursive: true,
+            force: true,
+        });
+
+        await runShellCommand('npx prisma generate --schema=test-files/schema-folder --no-hints', {
             rejectOnError: true,
             hookUpToConsole: true,
         });

--- a/test-files/schema-folder/region.prisma
+++ b/test-files/schema-folder/region.prisma
@@ -1,0 +1,7 @@
+model Region {
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  regionName String @id
+  users      User[]
+}

--- a/test-files/schema-folder/schema.prisma
+++ b/test-files/schema-folder/schema.prisma
@@ -1,0 +1,14 @@
+generator jsClient {
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder"]
+}
+
+generator jsFrontend {
+    provider = "tsx src/cli.script.ts"
+}
+
+datasource db {
+    provider = "postgresql"
+    // we won't actually be connecting to a real database in tests
+    url      = env("DB_URL")
+}

--- a/test-files/schema-folder/user.prisma
+++ b/test-files/schema-folder/user.prisma
@@ -1,0 +1,62 @@
+enum Status {
+  Active
+  Inactive
+}
+
+model User {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  email    String
+  password String
+
+  firstName   String?
+  lastName    String?
+  role        String?
+  phoneNumber String?
+  status      Status
+
+  settings UserSettings?
+  posts    UserPost[]
+  regions  Region[]
+}
+
+model UserPost {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  title String
+  body  String
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model UserSettings {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  receivesMarketingEmails Boolean @default(false)
+  canViewReports          Boolean @default(false)
+
+  userId String @unique
+
+  stats UserStats?
+  user  User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model UserStats {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  likes    Int
+  dislikes Int
+  views    Int
+
+  userSettingsId String       @unique
+  settings       UserSettings @relation(fields: [userSettingsId], references: [id], onDelete: Cascade)
+}


### PR DESCRIPTION
Prisma now supports defining the schema in multiple smaller files via the [`prismaSchemaFolder` preview feature](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema).
When this is enabled this generator fails to generate due to this error:
```
EISDIR: illegal operation on a directory, read
```

In [waitForClientJs](https://github.com/electrovir/prisma-frontend/blob/c252be8b01d75603211e74f775a9d457ef80dcdd/src/generator/wait-for-client-js.ts#L33) the generator reads the schema path as a file (which points to the `schema.prisma` file), but when the `prismaSchemaFolder` feature is enabled the schema path points to the schema directory, therefore `readFile` throws this error.

I had some free time so I gave it a go to add support for this preview feature, let me know what you think!